### PR TITLE
Fix ember-frost-password Demo error example

### DIFF
--- a/tests/dummy/app/pods/demo/template.hbs
+++ b/tests/dummy/app/pods/demo/template.hbs
@@ -13,7 +13,7 @@
 <div class='dummy-header'>Errored</div>
 
 <div style="padding: 10px 20px;">
-  {{frost-password id="errored" classNameBindings="errored"}}
+  {{frost-password id="errored" classNameBindings="error"}}
   {{#frost-button on-click=(action "toggleError") class="text small secondary"}}
       Toggle error
   {{/frost-button}}


### PR DESCRIPTION
# patch# Fix for ember-frost-password demo Toggle error example doing nothing
